### PR TITLE
Fix warning: elided named lifetime.

### DIFF
--- a/src-tauri/crates/eloelo_model/src/player.rs
+++ b/src-tauri/crates/eloelo_model/src/player.rs
@@ -65,7 +65,7 @@ impl PlayerDb {
         &'a self,
         players: &'a [PlayerId],
         game: &'a GameId,
-    ) -> impl IntoIterator<Item = (&PlayerId, i32)> + 'a {
+    ) -> impl IntoIterator<Item = (&'a PlayerId, i32)> + 'a {
         self.players
             .iter()
             .filter(|(k, _)| players.contains(k))


### PR DESCRIPTION
$ cargo build
   Compiling eloelo_model v0.1.0 (C:\maciek\programowanie\eloelo\src-tauri\crates\eloelo_model)
warning: elided lifetime has a name
  --> crates\eloelo_model\src\player.rs:68:36
   |
64 |     pub fn get_ranked<'a>(
   |                       -- lifetime `'a` declared here
...
68 |     ) -> impl IntoIterator<Item = (&PlayerId, i32)> + 'a {
   |                                    ^ this elided lifetime gets resolved as `'a`
   |
   = note: `#[warn(elided_named_lifetimes)]` on by default