### PR TITLE
Better hero randomization

### DIFF
--- a/src-tauri/crates/eloelo_model/src/player.rs
+++ b/src-tauri/crates/eloelo_model/src/player.rs
@@ -114,6 +114,19 @@ impl From<String> for DiscordUsername {
     }
 }
 
+impl From<&str> for DiscordUsername {
+    fn from(value: &str) -> Self {
+        DiscordUsername(String::from(value))
+    }
+}
+
+#[cfg(test)]
+impl std::borrow::Borrow<str> for DiscordUsername {
+    fn borrow(&self) -> &str {
+        &self.0
+    }
+}
+
 impl std::fmt::Display for DiscordUsername {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)


### PR DESCRIPTION
Properly handle multiple players randomizing:
- no conflicting choices
- try to provide decent choice for small allow list players while not reserving these heroes for them
- sometimes may run out of heroes and provide smaller (or no) reommendation