### PR TITLE
Add random hero duplication avoidance

### DIFF
--- a/src/eloelo/elodisco/bot_state.rs
+++ b/src/eloelo/elodisco/bot_state.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
+use chrono::{DateTime, Local};
 use eloelo_model::player::DiscordUsername;
 use serde::{Deserialize, Serialize};
 
@@ -27,4 +28,17 @@ pub struct DotaBotState {
 
     /// List of allowed heroes. If not empty, randomizer will use only this pool.
     pub allowed_heroes: HashSet<Hero>,
+
+    /// List of heroes offered last match.
+    #[serde(default)]
+    pub last_match_heroes: HashSet<Hero>,
+
+    /// Date of the last match.
+    #[serde(default)]
+    pub last_match_date: Option<DateTime<Local>>,
+
+    /// Explicit opt-out from duplicate heroes avoidance. With this set to true,
+    /// the algorithm won't try to avoid presenting same hero twice in a row.
+    #[serde(default)]
+    pub duplicate_heroes_opt_out: bool,
 }

--- a/src/eloelo/message_bus.rs
+++ b/src/eloelo/message_bus.rs
@@ -139,15 +139,6 @@ impl From<String> for AvatarUrl {
 
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-pub struct RoleRecommendation {
-    pub id: PlayerId,
-    pub username: DiscordUsername, // TODO: Probably keep only one of the ids (the more convenient
-    // from producer perspective
-    pub recommendation: Vec<String>,
-}
-
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
 pub struct DiscordPlayerInfo {
     pub id: PlayerId,
     pub display_name: String,


### PR DESCRIPTION
Do not roll heroes that were available in previous game for a given player. A flag available to opt-out for players who want original behavior. Only recently played matches affect the roll.